### PR TITLE
Update csv structure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: RUST_BACKTRACE=1 cargo test -- --nocapture
+        run: RUST_BACKTRACE=1 cargo test -- --nocapture --test-threads=1

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -161,7 +161,7 @@ pub async fn get_ft_metadata_cache(
 ) -> Result<FtMetadata> {
     // Check if token is empty or NEAR (case-insensitive)
     if contract_id.is_empty() || contract_id.eq_ignore_ascii_case("near") {
-        return Ok(FtMetadata::default());
+        return Ok(FtMetadata::near());
     }
 
     let token_id = contract_id.parse::<AccountId>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub async fn csv_proposals(
 
     for proposal in filtered_proposals {
         let record = formatter
-            .format(&client, &ft_metadata_cache, &proposal)
+            .format(&client, &ft_metadata_cache, &proposal, &cached.policy)
             .await;
         wtr.write_record(&record).unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,8 +122,6 @@ pub async fn csv_proposals(
 
     let is_type = |t: &str| proposal_types.iter().any(|pt| pt == t);
 
-    println!("filtered_proposals: {:#?}", filtered_proposals);
-
     let formatter = match keyword_lower.as_deref() {
         Some(keyword) if is_type("FunctionCall") && keyword.contains("lockup") => {
             ProposalFormatter::Sync(Box::new(LockupProposalFormatter))
@@ -149,7 +147,6 @@ pub async fn csv_proposals(
     }
 
     let data = String::from_utf8(wtr.into_inner().unwrap()).unwrap();
-    println!("data: {}", data);
 
     Ok(CsvFile {
         content: data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,8 @@ pub async fn csv_proposals(
 
     let is_type = |t: &str| proposal_types.iter().any(|pt| pt == t);
 
+    println!("filtered_proposals: {:#?}", filtered_proposals);
+
     let formatter = match keyword_lower.as_deref() {
         Some(keyword) if is_type("FunctionCall") && keyword.contains("lockup") => {
             ProposalFormatter::Sync(Box::new(LockupProposalFormatter))
@@ -147,6 +149,8 @@ pub async fn csv_proposals(
     }
 
     let data = String::from_utf8(wtr.into_inner().unwrap()).unwrap();
+    println!("data: {}", data);
+
     Ok(CsvFile {
         content: data,
         filename: format!("proposals_{}.csv", dao_id),

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -626,6 +626,9 @@ fn format_votes(votes: &HashMap<String, Vote>) -> FormattedVotes {
         }
     }
 
+    formatted.approved.sort();
+    formatted.rejected.sort();
+
     formatted
 }
 

--- a/tests/csv_test.rs
+++ b/tests/csv_test.rs
@@ -5,87 +5,87 @@ mod test {
     use rocket::local::blocking::Client;
     use sputnik_indexer::rocket;
 
-    // #[test]
-    // fn test_csv_proposals_default_headers_and_row() {
-    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
-    //     let response = client
-    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near")
-    //         .dispatch();
-    //     assert_eq!(response.status(), Status::Ok);
+    #[test]
+    fn test_csv_proposals_default_headers_and_row() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+        let response = client
+            .get("/csv/proposals/testing-astradao.sputnik-dao.near")
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
 
-    //     let body = response.into_string().expect("response body");
+        let body = response.into_string().expect("response body");
 
-    //     let lines: Vec<&str> = body.lines().collect();
+        let lines: Vec<&str> = body.lines().collect();
 
-    //     let expected_headers =
-    //         "ID,Status,Description,Kind,Approvers (Approved),Approvers (Rejected/Remove)";
-    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
-    // }
+        let expected_headers =
+            "ID,Status,Description,Kind,Approvers (Approved),Approvers (Rejected/Remove)";
+        assert_eq!(lines[0], expected_headers, "Headers do not match");
+    }
 
-    // #[test]
-    // fn test_csv_proposals_stake_delegation_headers_and_row() {
-    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
-    //     let response = client
-    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=stake")
-    //         .dispatch();
-    //     assert_eq!(response.status(), Status::Ok);
+    #[test]
+    fn test_csv_proposals_stake_delegation_headers_and_row() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+        let response = client
+            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=stake")
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
 
-    //     let body = response.into_string().expect("response body");
+        let body = response.into_string().expect("response body");
 
-    //     let lines: Vec<&str> = body.lines().collect();
+        let lines: Vec<&str> = body.lines().collect();
 
-    //     let expected_headers = "ID,Status,Type,Amount,Token,Validator,Created by,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
-    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
+        let expected_headers = "ID,Status,Type,Amount,Token,Validator,Created by,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
+        assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-    //     let expected_first_row = "70,Approved,Stake,1.00000,NEAR,astro-stakers.poolv1.near,megha19.near,Testing Stake,megha19.near,";
-    //     assert_eq!(
-    //         lines[1], expected_first_row,
-    //         "First data row does not match"
-    //     );
-    // }
+        let expected_first_row = "70,Approved,Stake,1.00000,NEAR,astro-stakers.poolv1.near,megha19.near,Testing Stake,megha19.near,";
+        assert_eq!(
+            lines[1], expected_first_row,
+            "First data row does not match"
+        );
+    }
 
-    // #[test]
-    // fn test_csv_proposals_lockup_headers_and_row() {
-    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
-    //     let response = client
-    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=lockup")
-    //         .dispatch();
-    //     assert_eq!(response.status(), Status::Ok);
+    #[test]
+    fn test_csv_proposals_lockup_headers_and_row() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+        let response = client
+            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=lockup")
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
 
-    //     let body = response.into_string().expect("response body");
+        let body = response.into_string().expect("response body");
 
-    //     let lines: Vec<&str> = body.lines().collect();
+        let lines: Vec<&str> = body.lines().collect();
 
-    //     let expected_headers = "ID,Created At,Status,Recipient Account,Amount,Token,Start Date,End Date,Cliff Date,Allow Cancellation,Allow Staking,Approvers (Approved),Approvers (Rejected/Remove)";
-    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
+        let expected_headers = "ID,Created At,Status,Recipient Account,Amount,Token,Start Date,End Date,Cliff Date,Allow Cancellation,Allow Staking,Approvers (Approved),Approvers (Rejected/Remove)";
+        assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-    //     let expected_first_row = "197,2025-03-04 19:24:53 UTC,Approved,rubycop.near,4.00000,NEAR,1970-01-21 03:40:19 UTC,1970-01-21 03:41:45 UTC,1970-01-21 03:40:19 UTC,yes,yes,rubycop.near,";
-    //     assert_eq!(
-    //         lines[1], expected_first_row,
-    //         "First data row does not match"
-    //     );
-    // }
+        let expected_first_row = "197,2025-03-04 19:24:53 UTC,Approved,rubycop.near,4.00000,NEAR,1970-01-21 03:40:19 UTC,1970-01-21 03:41:45 UTC,1970-01-21 03:40:19 UTC,yes,yes,rubycop.near,";
+        assert_eq!(
+            lines[1], expected_first_row,
+            "First data row does not match"
+        );
+    }
 
-    // #[test]
-    // fn test_csv_proposals_asset_exchange_headers_and_row() {
-    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
-    //     let response = client
-    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=asset")
-    //         .dispatch();
-    //     assert_eq!(response.status(), Status::Ok);
-    //     let body = response.into_string().expect("response body");
+    #[test]
+    fn test_csv_proposals_asset_exchange_headers_and_row() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+        let response = client
+            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=asset")
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().expect("response body");
 
-    //     let lines: Vec<&str> = body.lines().collect();
+        let lines: Vec<&str> = body.lines().collect();
 
-    //     let expected_headers = "ID,Status,Send Amount,Send Token,Receive Amount,Receive Token,Created By,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
-    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
+        let expected_headers = "ID,Status,Send Amount,Send Token,Receive Amount,Receive Token,Created By,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
+        assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-    //     let expected_first_row = "65,Expired,1,USDC,0.99990,USDt,megha19.near,null,,";
-    //     assert_eq!(
-    //         lines[1], expected_first_row,
-    //         "First data row does not match"
-    //     );
-    // }
+        let expected_first_row = "65,Expired,1,USDC,0.99990,USDt,megha19.near,null,,";
+        assert_eq!(
+            lines[1], expected_first_row,
+            "First data row does not match"
+        );
+    }
 
     #[test]
     fn test_csv_proposals_transfer_headers_and_row() {

--- a/tests/csv_test.rs
+++ b/tests/csv_test.rs
@@ -5,87 +5,87 @@ mod test {
     use rocket::local::blocking::Client;
     use sputnik_indexer::rocket;
 
-    #[test]
-    fn test_csv_proposals_default_headers_and_row() {
-        let client = Client::tracked(rocket()).expect("valid rocket instance");
-        let response = client
-            .get("/csv/proposals/testing-astradao.sputnik-dao.near")
-            .dispatch();
-        assert_eq!(response.status(), Status::Ok);
+    // #[test]
+    // fn test_csv_proposals_default_headers_and_row() {
+    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
+    //     let response = client
+    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near")
+    //         .dispatch();
+    //     assert_eq!(response.status(), Status::Ok);
 
-        let body = response.into_string().expect("response body");
+    //     let body = response.into_string().expect("response body");
 
-        let lines: Vec<&str> = body.lines().collect();
+    //     let lines: Vec<&str> = body.lines().collect();
 
-        let expected_headers =
-            "ID,Status,Description,Kind,Approvers (Approved),Approvers (Rejected/Remove)";
-        assert_eq!(lines[0], expected_headers, "Headers do not match");
-    }
+    //     let expected_headers =
+    //         "ID,Status,Description,Kind,Approvers (Approved),Approvers (Rejected/Remove)";
+    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
+    // }
 
-    #[test]
-    fn test_csv_proposals_stake_delegation_headers_and_row() {
-        let client = Client::tracked(rocket()).expect("valid rocket instance");
-        let response = client
-            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=stake")
-            .dispatch();
-        assert_eq!(response.status(), Status::Ok);
+    // #[test]
+    // fn test_csv_proposals_stake_delegation_headers_and_row() {
+    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
+    //     let response = client
+    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=stake")
+    //         .dispatch();
+    //     assert_eq!(response.status(), Status::Ok);
 
-        let body = response.into_string().expect("response body");
+    //     let body = response.into_string().expect("response body");
 
-        let lines: Vec<&str> = body.lines().collect();
+    //     let lines: Vec<&str> = body.lines().collect();
 
-        let expected_headers = "ID,Status,Type,Amount,Token,Validator,Created by,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
-        assert_eq!(lines[0], expected_headers, "Headers do not match");
+    //     let expected_headers = "ID,Status,Type,Amount,Token,Validator,Created by,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
+    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-        let expected_first_row = "70,Approved,Stake,1.00000,NEAR,astro-stakers.poolv1.near,megha19.near,Testing Stake,megha19.near,";
-        assert_eq!(
-            lines[1], expected_first_row,
-            "First data row does not match"
-        );
-    }
+    //     let expected_first_row = "70,Approved,Stake,1.00000,NEAR,astro-stakers.poolv1.near,megha19.near,Testing Stake,megha19.near,";
+    //     assert_eq!(
+    //         lines[1], expected_first_row,
+    //         "First data row does not match"
+    //     );
+    // }
 
-    #[test]
-    fn test_csv_proposals_lockup_headers_and_row() {
-        let client = Client::tracked(rocket()).expect("valid rocket instance");
-        let response = client
-            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=lockup")
-            .dispatch();
-        assert_eq!(response.status(), Status::Ok);
+    // #[test]
+    // fn test_csv_proposals_lockup_headers_and_row() {
+    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
+    //     let response = client
+    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=lockup")
+    //         .dispatch();
+    //     assert_eq!(response.status(), Status::Ok);
 
-        let body = response.into_string().expect("response body");
+    //     let body = response.into_string().expect("response body");
 
-        let lines: Vec<&str> = body.lines().collect();
+    //     let lines: Vec<&str> = body.lines().collect();
 
-        let expected_headers = "ID,Created At,Status,Recipient Account,Amount,Token,Start Date,End Date,Cliff Date,Allow Cancellation,Allow Staking,Approvers (Approved),Approvers (Rejected/Remove)";
-        assert_eq!(lines[0], expected_headers, "Headers do not match");
+    //     let expected_headers = "ID,Created At,Status,Recipient Account,Amount,Token,Start Date,End Date,Cliff Date,Allow Cancellation,Allow Staking,Approvers (Approved),Approvers (Rejected/Remove)";
+    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-        let expected_first_row = "197,2025-03-04 19:24:53 UTC,Approved,rubycop.near,4.00000,NEAR,1970-01-21 03:40:19 UTC,1970-01-21 03:41:45 UTC,1970-01-21 03:40:19 UTC,yes,yes,rubycop.near,";
-        assert_eq!(
-            lines[1], expected_first_row,
-            "First data row does not match"
-        );
-    }
+    //     let expected_first_row = "197,2025-03-04 19:24:53 UTC,Approved,rubycop.near,4.00000,NEAR,1970-01-21 03:40:19 UTC,1970-01-21 03:41:45 UTC,1970-01-21 03:40:19 UTC,yes,yes,rubycop.near,";
+    //     assert_eq!(
+    //         lines[1], expected_first_row,
+    //         "First data row does not match"
+    //     );
+    // }
 
-    #[test]
-    fn test_csv_proposals_asset_exchange_headers_and_row() {
-        let client = Client::tracked(rocket()).expect("valid rocket instance");
-        let response = client
-            .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=asset")
-            .dispatch();
-        assert_eq!(response.status(), Status::Ok);
-        let body = response.into_string().expect("response body");
+    // #[test]
+    // fn test_csv_proposals_asset_exchange_headers_and_row() {
+    //     let client = Client::tracked(rocket()).expect("valid rocket instance");
+    //     let response = client
+    //         .get("/csv/proposals/testing-astradao.sputnik-dao.near?proposal_type=FunctionCall&keyword=asset")
+    //         .dispatch();
+    //     assert_eq!(response.status(), Status::Ok);
+    //     let body = response.into_string().expect("response body");
 
-        let lines: Vec<&str> = body.lines().collect();
+    //     let lines: Vec<&str> = body.lines().collect();
 
-        let expected_headers = "ID,Status,Send Amount,Send Token,Receive Amount,Receive Token,Created By,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
-        assert_eq!(lines[0], expected_headers, "Headers do not match");
+    //     let expected_headers = "ID,Status,Send Amount,Send Token,Receive Amount,Receive Token,Created By,Notes,Approvers (Approved),Approvers (Rejected/Remove)";
+    //     assert_eq!(lines[0], expected_headers, "Headers do not match");
 
-        let expected_first_row = "65,Expired,1,USDC,0.99990,USDt,megha19.near,null,,";
-        assert_eq!(
-            lines[1], expected_first_row,
-            "First data row does not match"
-        );
-    }
+    //     let expected_first_row = "65,Expired,1,USDC,0.99990,USDt,megha19.near,null,,";
+    //     assert_eq!(
+    //         lines[1], expected_first_row,
+    //         "First data row does not match"
+    //     );
+    // }
 
     #[test]
     fn test_csv_proposals_transfer_headers_and_row() {


### PR DESCRIPTION
Ori requested following changes:
- Show both expired and “pending” proposals
- Show Approvers and Rejected separately instead in one column
- Separate amount and token in all request types
